### PR TITLE
Feature/edit layout

### DIFF
--- a/app/Http/Controllers/LayoutController.php
+++ b/app/Http/Controllers/LayoutController.php
@@ -30,8 +30,6 @@ class LayoutController extends Controller
         if($layout->css !== ""){
             $layout->css = file_get_contents($layout->css);
         }
-        
-        
         return Inertia::render('Layouts/Edit', ["layout" => $layout]);
     }
     private function uploadFile($fileName, $file, $storage_path){
@@ -75,18 +73,11 @@ class LayoutController extends Controller
         $uploadedCssUrl = "";
         if ($css !== null) {
             $cssName = uniqid() . '.css';
-            $cssURL = $this->uploadFile($cssName, $css, $storage_path);
+            $uploadedCssUrl = $this->uploadFile($cssName, $css, $storage_path);
         }
         $imageDataUrl = $request->input('image');
         $uploadedImageUrl = $this->uploadImage($imageDataUrl, $storage_path);
         
-        // URLからダウンロードできるか確認
-        // $htmlGot = file_get_contents($uploadedHtmlUrl);
-        // dd($htmlGot);
-        // dd($uploadedHtmlUrl . '\n' . 
-        //     $uploadedCssUrl . '\n' . 
-        //     $uploadedImageUrl);
-
         // uploadしたurlを返す
         $input = [
             'html' => $uploadedHtmlUrl,

--- a/app/Http/Controllers/LayoutController.php
+++ b/app/Http/Controllers/LayoutController.php
@@ -22,6 +22,18 @@ class LayoutController extends Controller
     {
         return Inertia::render('Layouts/Create');
     }
+    public function edit(Layout $layout)
+    {   
+        if($layout->html !== ""){
+            $layout->html = file_get_contents($layout->html);
+        }
+        if($layout->css !== ""){
+            $layout->css = file_get_contents($layout->css);
+        }
+        
+        
+        return Inertia::render('Layouts/Edit', ["layout" => $layout]);
+    }
     private function uploadFile($fileName, $file, $storage_path){
         Storage::disk('public')->put('tmp/' . $fileName, $file);
         $uploadedFileUrl = Cloudinary::uploadFile($storage_path . '/' . $fileName)->getSecurePath();

--- a/resources/js/Pages/Layouts/Edit.jsx
+++ b/resources/js/Pages/Layouts/Edit.jsx
@@ -8,6 +8,7 @@ import Preview from "../../Components/Layouts/Preview";
 
 export default function Edit(props) {
     const { layout } = props;
+    const isOwner = props.auth.user.id === layout.user_id;
     const [html, setHtml] = useState(layout.html);
     const [css, setCss  ] = useState(layout.css);
     const [iframeDoc, setIframeDoc  ] = useState('');
@@ -25,7 +26,11 @@ export default function Edit(props) {
                 html: html,
                 css: css,                
             }
-            router.post("/layouts/create", data);
+            if(isOwner) {
+                router.put(`/layouts/${layout.id}`, data)
+            } else {
+                router.post("/layouts/create", data);
+            }
         })        
     }
     return (

--- a/resources/js/Pages/Layouts/Edit.jsx
+++ b/resources/js/Pages/Layouts/Edit.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import html2canvas from 'html2canvas';
+import { router } from '@inertiajs/react'
+import Authenticated from "@/Layouts/AuthenticatedLayout";
+
+import Editor from "../../Components/Layouts/Editor";
+import Preview from "../../Components/Layouts/Preview";
+
+export default function Edit(props) {
+    const { layout } = props;
+    const [html, setHtml] = useState(layout.html);
+    const [css, setCss  ] = useState(layout.css);
+    const [iframeDoc, setIframeDoc  ] = useState('');
+        
+    // 送信用関数を追加
+    const handleSendPosts = (e) => {
+        e.preventDefault(); 
+        let imageUrl = "";
+        // Make sure the iframe's content is fully loaded before capturing
+        html2canvas(iframeDoc.body).then(function (canvas) {
+            const img = canvas.toDataURL('image/png');
+            imageUrl = img;
+            const data = {
+                image: imageUrl, 
+                html: html,
+                css: css,                
+            }
+            router.post("/layouts/create", data);
+        })        
+    }
+    return (
+        <Authenticated user={props.auth.user} header={
+            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                Edit
+            </h2>
+        }>
+            <button type="submit" onClick={handleSendPosts}>保存</button>                            
+            <Editor html={html} css={css} 
+                onHtmlChange={setHtml} onCssChange={setCss} />            
+            <Preview html={html} css={css}
+                onImageChange={setIframeDoc} />
+        </Authenticated>
+    );
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ Route::get('/layouts', [LayoutController::class, 'index'])->name('index');
 Route::get('/layouts/create', [LayoutController::class, 'create'])->name('create');   
 Route::post('/layouts/create', [LayoutController::class, 'store'])->name('layouts.store');
 Route::get('/layouts/{layout}', [LayoutController::class, 'edit'])->name('layouts.edit');
+Route::put('/layouts/{layout}', [LayoutController::class, 'store'])->name('layouts.update');
 
 //*****ここからデフォルトのルーティング*****/
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ Route::get('/', function () {
 Route::get('/layouts', [LayoutController::class, 'index'])->name('index');
 Route::get('/layouts/create', [LayoutController::class, 'create'])->name('create');   
 Route::post('/layouts/create', [LayoutController::class, 'store'])->name('layouts.store');
+Route::get('/layouts/{layout}', [LayoutController::class, 'edit'])->name('layouts.edit');
 
 //*****ここからデフォルトのルーティング*****/
 


### PR DESCRIPTION
レイアウトの作成とレイアウトの編集はほぼ同じ

異なる点
- クライアント
  - レイアウトの作成者か否か判断
    - レイアウトの作成者ならput
    - そうでないならpost(作成時と同じapi
- サーバサイド
  - レイアウトの作成者の場合のapi
  - レイアウト編集時に選択したレイアウトのhtml, cssを取得してそれをクライアントに送信
  - cssをcloudinaryに保存できていないバグの修正